### PR TITLE
update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ In some cases, you may want to customize the values that are sent to Algolia dur
 
 To customize the indexing process, you can override the `OnIndexingProperty()` that is defined in the search model base class `AlgoliaSearchModel`. This method is called during the indexing of a page for each property defined in your search model. You can use the function parameters such as the page being indexed, the value that would be indexed, the search model property name, and the name of the database column the value was retrieved from.
 
-We can use the [generated code](https://docs.xperience.io/xp/developers-and-admins/development/content-retrieval/generate-code-files-for-xperience-objects) of a content type to retrieve the text from the linked content items. Then we can store the text from the linked content items and store the text in our "Content" field:
+We can use the [generated code](https://docs.xperience.io/xp/developers-and-admins/development/content-retrieval/generate-code-files-for-xperience-objects) of a content type to retrieve the text from the linked content items. If we return the combined text from the linked content types, it will be stored in our "Content" field:
 
 ```cs
 public override object OnIndexingProperty(TreeNode node, string propertyName, string usedColumn, object foundValue)


### PR DESCRIPTION
### Motivation

TW review of the readme file attached to this repo.

Notable changes:
- Page types terminology replaced with content types to align with the new naming
- Removed some forgotten mentions of e-commerce, products, and stores
- Added more detail to some of the code samples

### A couple of questions/issues for Eric

1. Under "**Customizing the indexing process**," you state: 

"However, if we are indexing the "About Us" page in Dancing Goat, the content of the page actually comes from the child pages."

After the introduction of content types, we no longer recommend (content-only) child pages (not sure if they can even be created anymore). The DG sample was reworked as well, you can check that About us is just a standalone page now.

Instead, you are supposed to link other content types to the page via the Content items data type field and the corresponding selector (https://docs.xperience.io/xp/developers-and-admins/customization/field-editor/data-type-management). To retrieve the linked content, you use a new TreeNode property - https://docs.xperience.io/xp/developers-and-admins/development/content-retrieval/retrieve-linked-content-items

So IMHO the example should be reworked to this new approach and not mention child pages at all.

2. In the **Splitting large content** section you state:

"The IDs should ___not___ be random! Calling `SplitData()` on the same node multiple times should always generate the same fragments and IDs." 

Should or must? Important distinction :)
- will generating random IDs lead to data duplication and result in bloat/pollution of the index?
	- if so, then definitely change the wording to MUST