### PR TITLE
Fix NuGet push commands

### DIFF
--- a/build-and-release.yaml
+++ b/build-and-release.yaml
@@ -160,13 +160,17 @@ stages:
                         artifact: artifact
                         path: $(Build.ArtifactStagingDirectory)
 
-                    - task: UseDotNet@2
-                      displayName: Select dotnet version
+                    - task: NuGetToolInstaller@1
+                      displayName: Install nuget.exe
                       inputs:
-                        packageType: sdk
-                        version: ${{ variables.DotNetSdkVersion }}
+                        versionSpec: '>=5.6'
+                        checkLatest: true
 
-                    - task: DotNetCoreCLI@2
+                    - task: NuGetAuthenticate@0
+                      displayName: NuGet Authenticate
+
+                    - task: NuGetCommand@2
+                      displayName: NuGet push
                       inputs:
                         command: push
                         packagesToPush: $(Build.ArtifactStagingDirectory)/*.nupkg;$(Build.ArtifactStagingDirectory)/*.snupkg;


### PR DESCRIPTION
### Motivation

At this moment the `DotnetCoreCli@2` task doesn't support API-key-based service connections to push into the `nuget.org`. Using the `NuGetCommand@2` task is the preferred version.

