### PR TITLE
Fix NuGet symbol push

### DIFF
--- a/build-and-release.yaml
+++ b/build-and-release.yaml
@@ -173,6 +173,6 @@ stages:
                       displayName: NuGet push
                       inputs:
                         command: push
-                        packagesToPush: $(Build.ArtifactStagingDirectory)/*.nupkg;$(Build.ArtifactStagingDirectory)/*.snupkg;
+                        packagesToPush: $(Build.ArtifactStagingDirectory)/*.nupkg
                         nuGetFeedType: external
                         publishFeedCredentials: nuget.org


### PR DESCRIPTION
### Motivation

NuGet pushes both `nupkg` and `snupkg` together, so we need to remove explicit publish of the `snupkg` package. 

Check [here](https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#publishing-a-symbol-package) for more information