### PR TITLE
fix Algolia indexing issue for non default culture

### DIFF
--- a/src/Kentico.Xperience.Algolia.csproj
+++ b/src/Kentico.Xperience.Algolia.csproj
@@ -12,7 +12,7 @@
 	<PropertyGroup>
 		<Title>Xperience by Kentico Algolia Search</Title>
 		<PackageId>Kentico.Xperience.Algolia</PackageId>
-		<Version>2.0.1</Version>
+		<Version>2.0.2</Version>
 		<Authors>Kentico Software</Authors>
 		<Company>Kentico Software</Company>
 		<PackageIcon>icon.png</PackageIcon>

--- a/src/Services/Implementations/DefaultAlgoliaClient.cs
+++ b/src/Services/Implementations/DefaultAlgoliaClient.cs
@@ -283,6 +283,8 @@ namespace Kentico.Xperience.Algolia.Services
                     q.Path(includedPathAttribute.AliasPath)
                         .PublishedVersion()
                         .WithCoupledColumns();
+
+                    q.AllCultures();
                 }, cancellationToken: cancellationToken);
                     
                 indexedNodes.AddRange(nodes);


### PR DESCRIPTION
pages in cultures othe than 'en-US' were not indexed because default culture is resolved to 'en-US' `AllCultures()` is used in document query because culture filter is not needed for single culture site

### Motivation

Fixes #20 

