### PR TITLE
Algolia Installer work around to solve problem where Application is n…

### DIFF
--- a/src/Kentico.Xperience.Algolia/Admin/AlgoliaAdminModule.cs
+++ b/src/Kentico.Xperience.Algolia/Admin/AlgoliaAdminModule.cs
@@ -16,7 +16,7 @@ namespace Kentico.Xperience.Algolia.Admin;
 internal class AlgoliaAdminModule : AdminModule
 {
     private IAlgoliaConfigurationStorageService storageService = null!;
-    private IServiceProvider serviceProvider = null!;
+    private AlgoliaModuleInstaller installer = null!;
 
     public AlgoliaAdminModule() : base(nameof(AlgoliaAdminModule)) { }
 
@@ -25,15 +25,16 @@ internal class AlgoliaAdminModule : AdminModule
         base.OnInit(parameters);
         RegisterClientModule("kentico", "xperience-integrations-algolia");
 
-        serviceProvider = parameters.Services;
-        storageService = serviceProvider.GetRequiredService<IAlgoliaConfigurationStorageService>();
+        var services = parameters.Services;
+
+        installer = services.GetRequiredService<AlgoliaModuleInstaller>();
+        storageService = services.GetRequiredService<IAlgoliaConfigurationStorageService>();
 
         ApplicationEvents.PostStart.Execute += InitializeModule;
     }
 
     private void InitializeModule(object? sender, EventArgs e)
     {
-        var installer = serviceProvider.GetRequiredService<AlgoliaModuleInstaller>();
         installer.Install();
 
         AlgoliaIndexStore.SetIndicies(storageService);

--- a/src/Kentico.Xperience.Algolia/Admin/AlgoliaAdminModule.cs
+++ b/src/Kentico.Xperience.Algolia/Admin/AlgoliaAdminModule.cs
@@ -16,26 +16,24 @@ namespace Kentico.Xperience.Algolia.Admin;
 internal class AlgoliaAdminModule : AdminModule
 {
     private IAlgoliaConfigurationStorageService storageService = null!;
-    private AlgoliaModuleInstaller installer = null!;
+    private IServiceProvider serviceProvider = null!;
 
     public AlgoliaAdminModule() : base(nameof(AlgoliaAdminModule)) { }
 
     protected override void OnInit(ModuleInitParameters parameters)
     {
         base.OnInit(parameters);
-
         RegisterClientModule("kentico", "xperience-integrations-algolia");
 
-        var services = parameters.Services;
+        serviceProvider = parameters.Services;
+        storageService = serviceProvider.GetRequiredService<IAlgoliaConfigurationStorageService>();
 
-        installer = services.GetRequiredService<AlgoliaModuleInstaller>();
-        storageService = services.GetRequiredService<IAlgoliaConfigurationStorageService>();
-
-        ApplicationEvents.Initialized.Execute += InitializeModule;
+        ApplicationEvents.PostStart.Execute += InitializeModule;
     }
 
     private void InitializeModule(object? sender, EventArgs e)
     {
+        var installer = serviceProvider.GetRequiredService<AlgoliaModuleInstaller>();
         installer.Install();
 
         AlgoliaIndexStore.SetIndicies(storageService);

--- a/src/Kentico.Xperience.Algolia/AlgoliaSearchModule.cs
+++ b/src/Kentico.Xperience.Algolia/AlgoliaSearchModule.cs
@@ -35,9 +35,12 @@ internal class AlgoliaSearchModule : Module
     {
         base.OnInit();
 
-        algoliaTaskLogger = Service.Resolve<IAlgoliaTaskLogger>();
-        appSettingsService = Service.Resolve<IAppSettingsService>();
-        conversionService = Service.Resolve<IConversionService>();
+        var services = parameters.Services;
+
+        algoliaTaskLogger = services.GetRequiredService<IAlgoliaTaskLogger>();
+        appSettingsService = services.GetRequiredService<IAppSettingsService>();
+        conversionService = services.GetRequiredService<IConversionService>();
+
 
         WebPageEvents.Publish.Execute += HandleEvent;
         WebPageEvents.Delete.Execute += HandleEvent;

--- a/src/Kentico.Xperience.Algolia/AlgoliaSearchModule.cs
+++ b/src/Kentico.Xperience.Algolia/AlgoliaSearchModule.cs
@@ -34,15 +34,11 @@ internal class AlgoliaSearchModule : Module
     protected override void OnInit(ModuleInitParameters parameters)
     {
         base.OnInit();
-        var services = parameters.Services;
 
-        services.GetRequiredService<AlgoliaModuleInstaller>().Install();
         algoliaTaskLogger = Service.Resolve<IAlgoliaTaskLogger>();
         appSettingsService = Service.Resolve<IAppSettingsService>();
         conversionService = Service.Resolve<IConversionService>();
 
-
-        AddRegisteredIndices();
         WebPageEvents.Publish.Execute += HandleEvent;
         WebPageEvents.Delete.Execute += HandleEvent;
         ContentItemEvents.Publish.Execute += HandleContentItemEvent;

--- a/src/Kentico.Xperience.Algolia/AlgoliaStartupExtensions.cs
+++ b/src/Kentico.Xperience.Algolia/AlgoliaStartupExtensions.cs
@@ -18,7 +18,7 @@ public static class AlgoliaStartupExtensions
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <param name="configuration">The application configuration.</param>
-    public static IServiceCollection AddKenticoAlgolia(this IServiceCollection services, IConfiguration configuration) =>
+    private static IServiceCollection AddKenticoAlgoliaInternal(this IServiceCollection services, IConfiguration configuration) =>
         services.AddSingleton<AlgoliaModuleInstaller>()
             .Configure<AlgoliaOptions>(configuration.GetSection(AlgoliaOptions.CMS_ALGOLIA_SECTION_NAME))
             .AddSingleton<IInsightsClient>(s =>
@@ -53,7 +53,7 @@ public static class AlgoliaStartupExtensions
     /// <returns></returns>
     public static IServiceCollection AddKenticoAlgolia(this IServiceCollection serviceCollection, Action<IAlgoliaBuilder> configure, IConfiguration configuration)
     {
-        serviceCollection.AddKenticoAlgolia(configuration);
+        serviceCollection.AddKenticoAlgoliaInternal(configuration);
 
         var builder = new AlgoliaBuilder(serviceCollection);
 
@@ -64,6 +64,24 @@ public static class AlgoliaStartupExtensions
             serviceCollection.AddTransient<DefaultAlgoliaIndexingStrategy>();
             builder.RegisterStrategy<DefaultAlgoliaIndexingStrategy>("Default");
         }
+
+        return serviceCollection;
+    }
+
+    /// <summary>
+    /// Adds Algolia services and custom module to application with <see cref="DefaultAlgoliaIndexingStrategy"/>
+    /// </summary>
+    /// <param name="serviceCollection"></param>
+    /// <param name="configuration">The application configuration.</param>
+    /// <returns></returns>
+    public static IServiceCollection AddKenticoAlgolia(this IServiceCollection serviceCollection, IConfiguration configuration)
+    {
+        serviceCollection.AddKenticoAlgoliaInternal(configuration);
+
+        var builder = new AlgoliaBuilder(serviceCollection);
+
+        serviceCollection.AddTransient<DefaultAlgoliaIndexingStrategy>();
+        builder.RegisterStrategy<DefaultAlgoliaIndexingStrategy>("Default");
 
         return serviceCollection;
     }


### PR DESCRIPTION
Contains work around to solve problem where Application is not initialized in Module.OnInit() to be able to work on version 28.2.x
Also contains startup extension method change where in default AddKenticoAlgolia DefaultStrategy was not included 
