### PR TITLE
Expose IncludedPaths property in AlgoliaIndex class

### DIFF
--- a/examples/DancingGoat/Search/DancingGoatSearchStartupExtensions.cs
+++ b/examples/DancingGoat/Search/DancingGoatSearchStartupExtensions.cs
@@ -13,7 +13,6 @@ public static class DancingGoatSearchStartupExtensions
             builder.RegisterStrategy<AdvancedSearchIndexingStrategy>("DancingGoatAdvancedExampleStrategy");
             builder.RegisterStrategy<SimpleSearchIndexingStrategy>("DancingGoatMinimalExampleStrategy");
             builder.RegisterStrategy<ReusableContentItemsIndexingStrategy>(nameof(ReusableContentItemsIndexingStrategy));
-            builder.RegisterStrategy<LinkedContentIndexingStrategy>(nameof(LinkedContentIndexingStrategy));
         }, configuration);
 
         services.AddHttpClient<WebCrawlerService>();

--- a/examples/DancingGoat/Search/DancingGoatSearchStartupExtensions.cs
+++ b/examples/DancingGoat/Search/DancingGoatSearchStartupExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using DancingGoat.Search.Services;
+
 using Kentico.Xperience.Algolia;
 
 namespace DancingGoat.Search;
@@ -7,10 +8,12 @@ public static class DancingGoatSearchStartupExtensions
 {
     public static IServiceCollection AddKenticoAlgoliaServices(this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddKenticoAlgolia(builder => {
+        services.AddKenticoAlgolia(builder =>
+        {
             builder.RegisterStrategy<AdvancedSearchIndexingStrategy>("DancingGoatAdvancedExampleStrategy");
             builder.RegisterStrategy<SimpleSearchIndexingStrategy>("DancingGoatMinimalExampleStrategy");
             builder.RegisterStrategy<ReusableContentItemsIndexingStrategy>(nameof(ReusableContentItemsIndexingStrategy));
+            builder.RegisterStrategy<LinkedContentIndexingStrategy>(nameof(LinkedContentIndexingStrategy));
         }, configuration);
 
         services.AddHttpClient<WebCrawlerService>();

--- a/src/Kentico.Xperience.Algolia/Admin/AlgoliaConfigurationModel.cs
+++ b/src/Kentico.Xperience.Algolia/Admin/AlgoliaConfigurationModel.cs
@@ -41,6 +41,7 @@ public class AlgoliaConfigurationModel
         AlgoliaIndexItemInfo index,
         IEnumerable<AlgoliaIndexLanguageItemInfo> indexLanguages,
         IEnumerable<AlgoliaIncludedPathItemInfo> indexPaths,
+        IEnumerable<AlgoliaContentTypeItemInfo> contentTypeItems,
         IEnumerable<AlgoliaIndexContentType> contentTypes,
         IEnumerable<AlgoliaReusableContentTypeItemInfo> reusableContentTypes
     )
@@ -60,7 +61,7 @@ public class AlgoliaConfigurationModel
               .ToList();
         Paths = indexPaths
             .Where(p => p.AlgoliaIncludedPathItemIndexItemId == index.AlgoliaIndexItemId)
-            .Select(p => new AlgoliaIndexIncludedPath(p, contentTypes))
+            .Select(p => new AlgoliaIndexIncludedPath(p, contentTypeItems, contentTypes))
             .ToList();
     }
 }

--- a/src/Kentico.Xperience.Algolia/Admin/AlgoliaConfigurationModel.cs
+++ b/src/Kentico.Xperience.Algolia/Admin/AlgoliaConfigurationModel.cs
@@ -64,4 +64,33 @@ public class AlgoliaConfigurationModel
             .Select(p => new AlgoliaIndexIncludedPath(p, contentTypeItems, contentTypes))
             .ToList();
     }
+
+
+    [Obsolete("This constructor does not support content type filtering by path. Use the constructor with contentTypeItems parameter instead.")]
+    public AlgoliaConfigurationModel(
+        AlgoliaIndexItemInfo index,
+        IEnumerable<AlgoliaIndexLanguageItemInfo> indexLanguages,
+        IEnumerable<AlgoliaIncludedPathItemInfo> indexPaths,
+        IEnumerable<AlgoliaIndexContentType> contentTypes,
+        IEnumerable<AlgoliaReusableContentTypeItemInfo> reusableContentTypes
+    )
+    {
+        Id = index.AlgoliaIndexItemId;
+        IndexName = index.AlgoliaIndexItemIndexName;
+        ChannelName = index.AlgoliaIndexItemChannelName;
+        RebuildHook = index.AlgoliaIndexItemRebuildHook;
+        StrategyName = index.AlgoliaIndexItemStrategyName;
+        LanguageNames = indexLanguages
+            .Where(l => l.AlgoliaIndexLanguageItemIndexItemId == index.AlgoliaIndexItemId)
+            .Select(l => l.AlgoliaIndexLanguageItemName)
+            .ToList();
+        ReusableContentTypeNames = reusableContentTypes
+              .Where(c => c.AlgoliaReusableContentTypeItemIndexItemId == index.AlgoliaIndexItemId)
+              .Select(c => c.AlgoliaReusableContentTypeItemContentTypeName)
+              .ToList();
+        Paths = indexPaths
+            .Where(p => p.AlgoliaIncludedPathItemIndexItemId == index.AlgoliaIndexItemId)
+            .Select(p => new AlgoliaIndexIncludedPath(p, contentTypes))
+            .ToList();
+    }
 }

--- a/src/Kentico.Xperience.Algolia/Admin/AlgoliaIndexIncludedPath.cs
+++ b/src/Kentico.Xperience.Algolia/Admin/AlgoliaIndexIncludedPath.cs
@@ -37,11 +37,16 @@ public class AlgoliaIndexIncludedPath
         IEnumerable<AlgoliaIndexContentType> contentTypes)
     {
         AliasPath = indexPath.AlgoliaIncludedPathItemAliasPath;
+
+        var contentTypesByName = contentTypes
+            .GroupBy(c => c.ContentTypeName, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+
         ContentTypes = contentTypeItems
             .Where(ct => ct.AlgoliaContentTypeItemIncludedPathItemId == indexPath.AlgoliaIncludedPathItemId)
-            .Select(ct => contentTypes.FirstOrDefault(c =>
-                string.Equals(c.ContentTypeName, ct.AlgoliaContentTypeItemContentTypeName, StringComparison.OrdinalIgnoreCase))
-                ?? new AlgoliaIndexContentType(ct.AlgoliaContentTypeItemContentTypeName, ct.AlgoliaContentTypeItemContentTypeName))
+            .Select(ct => contentTypesByName.TryGetValue(ct.AlgoliaContentTypeItemContentTypeName, out var contentType)
+                ? contentType
+                : new AlgoliaIndexContentType(ct.AlgoliaContentTypeItemContentTypeName, ct.AlgoliaContentTypeItemContentTypeName))
             .ToList();
         Identifier = indexPath.AlgoliaIncludedPathItemId.ToString();
     }

--- a/src/Kentico.Xperience.Algolia/Admin/AlgoliaIndexIncludedPath.cs
+++ b/src/Kentico.Xperience.Algolia/Admin/AlgoliaIndexIncludedPath.cs
@@ -42,12 +42,20 @@ public class AlgoliaIndexIncludedPath
             .GroupBy(c => c.ContentTypeName, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
 
-        ContentTypes = contentTypeItems
+        ContentTypes = [.. contentTypeItems
             .Where(ct => ct.AlgoliaContentTypeItemIncludedPathItemId == indexPath.AlgoliaIncludedPathItemId)
             .Select(ct => contentTypesByName.TryGetValue(ct.AlgoliaContentTypeItemContentTypeName, out var contentType)
                 ? contentType
-                : new AlgoliaIndexContentType(ct.AlgoliaContentTypeItemContentTypeName, ct.AlgoliaContentTypeItemContentTypeName))
-            .ToList();
+                : new AlgoliaIndexContentType(ct.AlgoliaContentTypeItemContentTypeName, ct.AlgoliaContentTypeItemContentTypeName))];
+        Identifier = indexPath.AlgoliaIncludedPathItemId.ToString();
+    }
+
+
+    [Obsolete("This constructor does not support content type filtering by path. Use the constructor with contentTypeItems parameter instead.")]
+    public AlgoliaIndexIncludedPath(AlgoliaIncludedPathItemInfo indexPath, IEnumerable<AlgoliaIndexContentType> contentTypes)
+    {
+        AliasPath = indexPath.AlgoliaIncludedPathItemAliasPath;
+        ContentTypes = contentTypes.ToList();
         Identifier = indexPath.AlgoliaIncludedPathItemId.ToString();
     }
 }

--- a/src/Kentico.Xperience.Algolia/Admin/AlgoliaIndexIncludedPath.cs
+++ b/src/Kentico.Xperience.Algolia/Admin/AlgoliaIndexIncludedPath.cs
@@ -24,14 +24,25 @@ public class AlgoliaIndexIncludedPath
     public AlgoliaIndexIncludedPath(string aliasPath) => AliasPath = aliasPath;
 
     /// <summary>
-    /// 
+    /// Reconstructs an included path from persisted data, attaching only the content
+    /// types that are linked to this specific path via
+    /// <see cref="AlgoliaContentTypeItemInfo.AlgoliaContentTypeItemIncludedPathItemId"/>.
     /// </summary>
-    /// <param name="indexPath"></param>
-    /// <param name="contentTypes"></param>
-    public AlgoliaIndexIncludedPath(AlgoliaIncludedPathItemInfo indexPath, IEnumerable<AlgoliaIndexContentType> contentTypes)
+    /// <param name="indexPath">The persisted included path.</param>
+    /// <param name="contentTypeItems">Content type link rows (may span multiple paths/indexes; filtered by path id).</param>
+    /// <param name="contentTypes">Resolved content type metadata used to provide display names.</param>
+    public AlgoliaIndexIncludedPath(
+        AlgoliaIncludedPathItemInfo indexPath,
+        IEnumerable<AlgoliaContentTypeItemInfo> contentTypeItems,
+        IEnumerable<AlgoliaIndexContentType> contentTypes)
     {
         AliasPath = indexPath.AlgoliaIncludedPathItemAliasPath;
-        ContentTypes = contentTypes.ToList();
+        ContentTypes = contentTypeItems
+            .Where(ct => ct.AlgoliaContentTypeItemIncludedPathItemId == indexPath.AlgoliaIncludedPathItemId)
+            .Select(ct => contentTypes.FirstOrDefault(c =>
+                string.Equals(c.ContentTypeName, ct.AlgoliaContentTypeItemContentTypeName, StringComparison.OrdinalIgnoreCase))
+                ?? new AlgoliaIndexContentType(ct.AlgoliaContentTypeItemContentTypeName, ct.AlgoliaContentTypeItemContentTypeName))
+            .ToList();
         Identifier = indexPath.AlgoliaIncludedPathItemId.ToString();
     }
 }

--- a/src/Kentico.Xperience.Algolia/Admin/DefaultAlgoliaConfigurationStorageService.cs
+++ b/src/Kentico.Xperience.Algolia/Admin/DefaultAlgoliaConfigurationStorageService.cs
@@ -138,7 +138,8 @@ internal class DefaultAlgoliaConfigurationStorageService : IAlgoliaConfiguration
         var contentTypesInfoItems = contentTypeProvider
         .Get()
         .WhereEquals(nameof(AlgoliaContentTypeItemInfo.AlgoliaContentTypeItemIndexItemId), indexInfo.AlgoliaIndexItemId)
-        .GetEnumerableTypedResult();
+        .GetEnumerableTypedResult()
+        .ToList();
 
         var contentTypes = DataClassInfoProvider.ProviderObject
             .Get()
@@ -148,7 +149,8 @@ internal class DefaultAlgoliaConfigurationStorageService : IAlgoliaConfiguration
                     .Select(x => x.AlgoliaContentTypeItemContentTypeName)
                     .ToArray()
             ).GetEnumerableTypedResult()
-            .Select(x => new AlgoliaIndexContentType(x.ClassName, x.ClassDisplayName));
+            .Select(x => new AlgoliaIndexContentType(x.ClassName, x.ClassDisplayName))
+            .ToList();
 
         var reusableContentTypes = reusableContentTypeProvider.Get().WhereEquals(nameof(AlgoliaReusableContentTypeItemInfo.AlgoliaReusableContentTypeItemIndexItemId), indexInfo.AlgoliaIndexItemId).GetEnumerableTypedResult();
 

--- a/src/Kentico.Xperience.Algolia/Admin/DefaultAlgoliaConfigurationStorageService.cs
+++ b/src/Kentico.Xperience.Algolia/Admin/DefaultAlgoliaConfigurationStorageService.cs
@@ -154,7 +154,7 @@ internal class DefaultAlgoliaConfigurationStorageService : IAlgoliaConfiguration
 
         var languages = languageProvider.Get().WhereEquals(nameof(AlgoliaIndexLanguageItemInfo.AlgoliaIndexLanguageItemIndexItemId), indexInfo.AlgoliaIndexItemId).GetEnumerableTypedResult();
 
-        return new AlgoliaConfigurationModel(indexInfo, languages, paths, contentTypes, reusableContentTypes);
+        return new AlgoliaConfigurationModel(indexInfo, languages, paths, contentTypesInfoItems, contentTypes, reusableContentTypes);
     }
 
 
@@ -192,7 +192,9 @@ internal class DefaultAlgoliaConfigurationStorageService : IAlgoliaConfiguration
 
         var reusableContentTypes = reusableContentTypeProvider.Get().ToList();
 
-        return indexInfos.Select(index => new AlgoliaConfigurationModel(index, languages, paths, contentTypes, reusableContentTypes));
+        var contentTypeItems = contentTypesInfoItems.ToList();
+
+        return indexInfos.Select(index => new AlgoliaConfigurationModel(index, languages, paths, contentTypeItems, contentTypes, reusableContentTypes));
     }
 
 

--- a/src/Kentico.Xperience.Algolia/Admin/DefaultAlgoliaConfigurationStorageService.cs
+++ b/src/Kentico.Xperience.Algolia/Admin/DefaultAlgoliaConfigurationStorageService.cs
@@ -174,25 +174,25 @@ internal class DefaultAlgoliaConfigurationStorageService : IAlgoliaConfiguration
 
         var paths = pathProvider.Get().ToList();
 
-        var contentTypesInfoItems = contentTypeProvider
+        var contentTypeItems = contentTypeProvider
             .Get()
-            .GetEnumerableTypedResult();
+            .GetEnumerableTypedResult()
+            .ToList();
 
         var contentTypes = DataClassInfoProvider.ProviderObject
             .Get()
             .WhereIn(
                 nameof(DataClassInfo.ClassName),
-                contentTypesInfoItems
+                contentTypeItems
                     .Select(x => x.AlgoliaContentTypeItemContentTypeName)
                     .ToArray()
             ).GetEnumerableTypedResult()
-            .Select(x => new AlgoliaIndexContentType(x.ClassName, x.ClassDisplayName));
+            .Select(x => new AlgoliaIndexContentType(x.ClassName, x.ClassDisplayName))
+            .ToList();
 
         var languages = languageProvider.Get().ToList();
 
         var reusableContentTypes = reusableContentTypeProvider.Get().ToList();
-
-        var contentTypeItems = contentTypesInfoItems.ToList();
 
         return indexInfos.Select(index => new AlgoliaConfigurationModel(index, languages, paths, contentTypeItems, contentTypes, reusableContentTypes));
     }

--- a/src/Kentico.Xperience.Algolia/Indexing/AlgoliaIndex.cs
+++ b/src/Kentico.Xperience.Algolia/Indexing/AlgoliaIndex.cs
@@ -37,7 +37,11 @@ public sealed class AlgoliaIndex
     /// </summary>
     public Type AlgoliaIndexingStrategyType { get; }
 
-    internal IEnumerable<AlgoliaIndexIncludedPath> IncludedPaths { get; set; }
+    /// <summary>
+    /// The included paths configured for this index in the Xperience admin UI,
+    /// along with the content types allowed at each path.
+    /// </summary>
+    public IEnumerable<AlgoliaIndexIncludedPath> IncludedPaths { get; internal set; }
 
     internal AlgoliaIndex(AlgoliaConfigurationModel indexConfiguration, Dictionary<string, Type> strategies)
     {

--- a/src/Kentico.Xperience.Algolia/Indexing/AlgoliaIndex.cs
+++ b/src/Kentico.Xperience.Algolia/Indexing/AlgoliaIndex.cs
@@ -37,11 +37,7 @@ public sealed class AlgoliaIndex
     /// </summary>
     public Type AlgoliaIndexingStrategyType { get; }
 
-    /// <summary>
-    /// The included paths configured for this index in the Xperience admin UI,
-    /// along with the content types allowed at each path.
-    /// </summary>
-    public IEnumerable<AlgoliaIndexIncludedPath> IncludedPaths { get; internal set; }
+    internal IEnumerable<AlgoliaIndexIncludedPath> IncludedPaths { get; set; }
 
     internal AlgoliaIndex(AlgoliaConfigurationModel indexConfiguration, Dictionary<string, Type> strategies)
     {


### PR DESCRIPTION
Included paths were internal, therefore when creating custom indexing strategy you could not use set values. Exposed this field so that it can be utilized in strategies

Which issue does this fix? Fixes #80


## Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

1. Add this sample strategy to project, add it to DancingGoatSearchStartupExtensions.
2. then create an index with following setup 
<img width="887" height="1092" alt="image" src="https://github.com/user-attachments/assets/82acb5ed-7830-4409-9a06-83f11cd0eba5" />

3. rebuild, check it indexes all banners linked to home pages.
4. change Included content types in path to Article page, save, rebuild index
5. see it now links all images linked to articles (different entry count)

`
using Algolia.Search.Models.Settings;

using CMS.ContentEngine;
using CMS.Websites;

using DancingGoat.Models;
using DancingGoat.Search.Models;

using Kentico.Xperience.Algolia.Indexing;

using Newtonsoft.Json.Linq;

namespace DancingGoat.Search;

/// <summary>
/// Indexes <see cref="HomePage"/> and <see cref="ArticlePage"/> web pages that match
/// the index's configured included paths + page content types. Each page record is
/// enriched with data from its linked reusable items, filtered by the reusable
/// content types selected on the index.
/// </summary>
/// <remarks>
/// Only a fixed link map is inspected:
/// <list type="bullet">
///   <item><see cref="HomePage.HomePageBanner"/> (<see cref="Banner"/>)</item>
///   <item><see cref="HomePage.HomePageEvent"/> (<see cref="Event"/>)</item>
///   <item><see cref="ArticlePage.ArticlePageTeaser"/> (<see cref="Image"/>)</item>
/// </list>
/// </remarks>
public class LinkedContentIndexingStrategy : DefaultAlgoliaIndexingStrategy
{
    private readonly IContentQueryExecutor queryExecutor;
    private readonly IWebPageQueryResultMapper webPageMapper;

    public LinkedContentIndexingStrategy(
        IContentQueryExecutor queryExecutor,
        IWebPageQueryResultMapper webPageMapper)
    {
        this.queryExecutor = queryExecutor;
        this.webPageMapper = webPageMapper;
    }

    public override IndexSettings GetAlgoliaIndexSettings() => new()
    {
        AttributesToRetrieve = new List<string>
        {
            nameof(DancingGoatSearchResultModel.Title),
            nameof(DancingGoatSearchResultModel.Content),
            nameof(DancingGoatSearchResultModel.ContentTypeName)
        },
        AttributesForFaceting = new List<string>
        {
            nameof(DancingGoatSearchResultModel.ContentTypeName)
        }
    };

    public override async Task<IEnumerable<JObject>?> MapToAlgoliaJObjectsOrNull(IIndexEventItemModel algoliaPageItem)
    {
        // Only web pages become records. Reusable items only contribute field data
        // through the pages that link to them.
        if (algoliaPageItem is not IndexEventWebPageItemModel indexedPage)
        {
            return null;
        }

        var index = AlgoliaIndexStore.Instance
            .GetAllIndices()
            .FirstOrDefault(i => i.WebSiteChannelName == indexedPage.WebsiteChannelName
                && i.AlgoliaIndexingStrategyType == typeof(LinkedContentIndexingStrategy));

        if (index is null)
        {
            return null;
        }

        var reusableTypes = new HashSet<string>(index.IncludedReusableContentTypes, StringComparer.OrdinalIgnoreCase);

        string? title = null;
        var contentParts = new List<string>();

        if (string.Equals(indexedPage.ContentTypeName, HomePage.CONTENT_TYPE_NAME, StringComparison.OrdinalIgnoreCase))
        {
            var page = await GetPage<HomePage>(indexedPage);
            if (page is null)
            {
                return null;
            }

            if (reusableTypes.Contains(Banner.CONTENT_TYPE_NAME) && page.HomePageBanner is not null)
            {
                foreach (var banner in page.HomePageBanner)
                {
                    title ??= banner.BannerHeaderText;
                    if (!string.IsNullOrWhiteSpace(banner.BannerText))
                    {
                        contentParts.Add(banner.BannerText);
                    }
                }
            }

            if (reusableTypes.Contains(Event.CONTENT_TYPE_NAME) && page.HomePageEvent is not null)
            {
                foreach (var ev in page.HomePageEvent)
                {
                    title ??= ev.EventTitle;
                    if (!string.IsNullOrWhiteSpace(ev.EventPromoText))
                    {
                        contentParts.Add(ev.EventPromoText);
                    }
                }
            }
        }
        else if (string.Equals(indexedPage.ContentTypeName, ArticlePage.CONTENT_TYPE_NAME, StringComparison.OrdinalIgnoreCase))
        {
            var page = await GetPage<ArticlePage>(indexedPage);
            if (page is null)
            {
                return null;
            }

            title = page.ArticleTitle;

            if (reusableTypes.Contains(Image.CONTENT_TYPE_NAME) && page.ArticlePageTeaser is not null)
            {
                foreach (var image in page.ArticlePageTeaser)
                {
                    if (!string.IsNullOrWhiteSpace(image.ImageShortDescription))
                    {
                        contentParts.Add(image.ImageShortDescription);
                    }
                }
            }
        }
        else
        {
            return null;
        }

        // Skip pages that have no data from any of the selected reusable content types.
        if (title is null && contentParts.Count == 0)
        {
            return null;
        }

        var jObject = new JObject
        {
            [nameof(DancingGoatSearchResultModel.Title)] = title ?? indexedPage.Name,
            [nameof(DancingGoatSearchResultModel.Content)] = string.Join(" ", contentParts)
        };

        return new List<JObject> { jObject };
    }

    public override async Task<IEnumerable<IIndexEventItemModel>> FindItemsToReindex(IndexEventReusableItemModel changedItem)
    {
        var reindexedItems = new List<IIndexEventItemModel>();

        foreach (var index in GetIndexesUsingThisStrategy())
        {
            // Only consider reusable types selected on this index.
            if (!index.IncludedReusableContentTypes.Exists(t =>
                string.Equals(t, changedItem.ContentTypeName, StringComparison.OrdinalIgnoreCase)))
            {
                continue;
            }

            if (string.Equals(changedItem.ContentTypeName, Banner.CONTENT_TYPE_NAME, StringComparison.OrdinalIgnoreCase))
            {
                var pages = await QueryLinkingWebPages<HomePage>(index, HomePage.CONTENT_TYPE_NAME, nameof(HomePage.HomePageBanner), changedItem.ItemID, changedItem.LanguageName);
                AddMatchingPages(pages, index, HomePage.CONTENT_TYPE_NAME, changedItem.LanguageName, reindexedItems);
            }
            else if (string.Equals(changedItem.ContentTypeName, Event.CONTENT_TYPE_NAME, StringComparison.OrdinalIgnoreCase))
            {
                var pages = await QueryLinkingWebPages<HomePage>(index, HomePage.CONTENT_TYPE_NAME, nameof(HomePage.HomePageEvent), changedItem.ItemID, changedItem.LanguageName);
                AddMatchingPages(pages, index, HomePage.CONTENT_TYPE_NAME, changedItem.LanguageName, reindexedItems);
            }
            else if (string.Equals(changedItem.ContentTypeName, Image.CONTENT_TYPE_NAME, StringComparison.OrdinalIgnoreCase))
            {
                var pages = await QueryLinkingWebPages<ArticlePage>(index, ArticlePage.CONTENT_TYPE_NAME, nameof(ArticlePage.ArticlePageTeaser), changedItem.ItemID, changedItem.LanguageName);
                AddMatchingPages(pages, index, ArticlePage.CONTENT_TYPE_NAME, changedItem.LanguageName, reindexedItems);
            }
        }

        return reindexedItems;
    }

    private void AddMatchingPages<T>(
        IEnumerable<T> pages,
        AlgoliaIndex index,
        string contentTypeName,
        string languageName,
        List<IIndexEventItemModel> destination)
        where T : IWebPageFieldsSource
    {
        foreach (var page in pages)
        {
            if (!IsOnIncludedPath(index, page.SystemFields.WebPageItemTreePath, contentTypeName))
            {
                continue;
            }

            destination.Add(new IndexEventWebPageItemModel(
                page.SystemFields.WebPageItemID,
                page.SystemFields.WebPageItemGUID,
                languageName,
                contentTypeName,
                page.SystemFields.WebPageItemName,
                page.SystemFields.ContentItemIsSecured,
                page.SystemFields.ContentItemContentTypeID,
                page.SystemFields.ContentItemCommonDataContentLanguageID,
                index.WebSiteChannelName,
                page.SystemFields.WebPageItemTreePath,
                page.SystemFields.WebPageItemParentID,
                page.SystemFields.WebPageItemOrder));
        }
    }

    private async Task<IEnumerable<T>> QueryLinkingWebPages<T>(
        AlgoliaIndex index,
        string contentTypeName,
        string linkingFieldName,
        int linkedItemId,
        string languageName)
        where T : IWebPageFieldsSource, new()
    {
        var query = new ContentItemQueryBuilder()
            .ForContentType(contentTypeName, config => config
                .WithLinkedItems(1)
                .ForWebsite(index.WebSiteChannelName)
                .Linking(linkingFieldName, new[] { linkedItemId }))
            .InLanguage(languageName);

        return await queryExecutor.GetWebPageResult(query, webPageMapper.Map<T>);
    }

    private async Task<T?> GetPage<T>(IndexEventWebPageItemModel indexedPage)
        where T : IWebPageFieldsSource, new()
    {
        var query = new ContentItemQueryBuilder()
            .ForContentType(indexedPage.ContentTypeName, config => config
                .WithLinkedItems(2)
                .ForWebsite(indexedPage.WebsiteChannelName)
                .Where(where => where.WhereEquals(nameof(WebPageFields.WebPageItemGUID), indexedPage.ItemGuid))
                .TopN(1))
            .InLanguage(indexedPage.LanguageName);

        var result = await queryExecutor.GetWebPageResult(query, webPageMapper.Map<T>);
        return result.FirstOrDefault();
    }

    private static IEnumerable<AlgoliaIndex> GetIndexesUsingThisStrategy() =>
        AlgoliaIndexStore.Instance
            .GetAllIndices()
            .Where(i => i.AlgoliaIndexingStrategyType == typeof(LinkedContentIndexingStrategy));

    private static bool IsOnIncludedPath(AlgoliaIndex index, string treePath, string contentTypeName) =>
        index.IncludedPaths.Any(p =>
        {
            bool contentTypeMatches = p.ContentTypes.Exists(ct =>
                string.Equals(ct.ContentTypeName, contentTypeName, StringComparison.OrdinalIgnoreCase));

            if (!contentTypeMatches)
            {
                return false;
            }

            if (p.AliasPath.EndsWith("/%", StringComparison.OrdinalIgnoreCase))
            {
                string prefix = p.AliasPath[..^2];
                return treePath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
            }

            return string.Equals(treePath, p.AliasPath, StringComparison.OrdinalIgnoreCase);
        });
}

`